### PR TITLE
Fixed code lists for pdf and removed unnecessary path

### DIFF
--- a/classes/ProjectData.php
+++ b/classes/ProjectData.php
@@ -162,17 +162,23 @@ class ProjectData
     }
 
     public static function replaceSymbolsForPDF($sopData){
-        $specialCharacters = ["&ge;", "&le;" ];
-        $specialCharactersReplacements = ["&gt;=","&lt;="];
-        $dataChanged = $sopData;
-
-        foreach($sopData as $index => $sop){
-            if(!is_array($sop)) {
-                #Only check data text no checkboxes, etc.
-                foreach ($specialCharacters as $specialChar => $replacementData) {
-                    $dataChanged[$index] = str_replace($specialCharacters, $specialCharactersReplacements, $dataChanged[$index]);
+        if(is_array($sopData)){
+            $specialCharacters = ["&ge;", "&le;" ];
+            $specialCharactersReplacements = ["&gt;=","&lt;="];
+            $dataChanged = $sopData;
+            foreach($sopData as $index => $sop){
+                if(!is_array($sop)) {
+                    #Only check data text no checkboxes, etc.
+                    foreach ($specialCharacters as $specialChar => $replacementData) {
+                        $dataChanged[$index] = str_replace($specialCharacters, $specialCharactersReplacements, $dataChanged[$index]);
+                    }
                 }
             }
+        }else{
+            #Case scenario Code Lists
+            $specialCharacters = [">", "<" ];
+            $specialCharactersReplacements = ["&gt;","&lt;"];
+            $dataChanged = str_replace($specialCharacters, $specialCharactersReplacements, $sopData);
         }
         return $dataChanged;
     }

--- a/functions.php
+++ b/functions.php
@@ -6,6 +6,7 @@ use Vanderbilt\HarmonistHubExternalModule\ProjectData;
 
 require_once 'vendor/autoload.php';
 require_once(dirname(__FILE__)."/classes/ArrayFunctions.php");
+require_once(dirname(__FILE__)."/classes/ProjectData.php");
 
 
 /**
@@ -1653,7 +1654,7 @@ function generateTablesHTML_pdf($module, $pidCodeList, $dataTable,$fieldsSelecte
                             $codeformat = \REDCap::getData($pidCodeList, 'json-array',array('record_id' => $data['code_list_ref'][$id]),array('code_format','code_list','code_file'));
 
                             if ($codeformat['code_format'] == '1') {
-                                $codeOptions = empty($codeformat['code_list']) ? $data['code_text'][$id] : explode(" | ", $codeformat['code_list']);
+                                $codeOptions = empty($codeformat['code_list']) ? $data['code_text'][$id] : explode(" | ", ProjectData::replaceSymbolsForPDF($codeformat['code_list']));
                                 if (!empty($codeOptions[0])) {
                                     $dataFormat .= "<div style='padding-left:15px'>";
                                 }

--- a/sop/sop_step_4_save_AJAX.php
+++ b/sop/sop_step_4_save_AJAX.php
@@ -25,14 +25,14 @@ foreach ($regions as $region){
     }
 }
 
-$dataTable = \Vanderbilt\HarmonistHubExternalModule\getTablesInfo($module, $pidsArray['DATAMODEL']);
+$dataTable = getTablesInfo($module, $pidsArray['DATAMODEL']);
 $tableHtml = "";
 if(!empty($dataTable)) {
     # Get selected rows
-    $tableHtml = \Vanderbilt\HarmonistHubExternalModule\generateTablesHTML_pdf($module, $pidsArray['CODELIST'], $dataTable,$sop['sop_tablefields']);
-    $requested_tables = \Vanderbilt\HarmonistHubExternalModule\generateRequestedTablesList_pdf($dataTable,$sop['sop_tablefields']);
+    $tableHtml = generateTablesHTML_pdf($module, $pidsArray['CODELIST'], $dataTable,$sop['sop_tablefields']);
+    $requested_tables = generateRequestedTablesList_pdf($dataTable,$sop['sop_tablefields']);
 
-    $dataTable = \Vanderbilt\HarmonistHubExternalModule\getTablesInfo($module, $pidsArray['DATAMODEL']);
+    $dataTable = getTablesInfo($module, $pidsArray['DATAMODEL']);
     $tablefields = array();
     foreach( $dataTable as $data ) {
         if (!empty($data['record_id'])) {
@@ -153,7 +153,7 @@ $second_page .= "<p><span style='font-size: 12pt'>".$requested_tables."</span></
 
 $page_num = '<style>.footer .page-number:after { content: counter(page); } .footer { position: fixed; bottom: 0px;color:grey }a{text-decoration: none;}</style>';
 
-$img = \Vanderbilt\HarmonistHubExternalModule\getFile($module, $pidsArray['PROJECTS'], $settings['hub_logo_pdf'],'src');
+$img = getFile($module, $pidsArray['PROJECTS'], $settings['hub_logo_pdf'],'src');
 
 $html_pdf = "<html><body style='font-family:\"Calibri\";font-size:10pt;'>".$page_num
     ."<div class='footer'><span left: 0px;>".$concept_id."</span></div>"


### PR DESCRIPTION
This is the same with the Plugin but removing also some unnecessary paths.
I'll explain today but we are going to move out of the Plugin environment in January so you might see code reviews of fixes for the Plugin that then I add to the EM. This way I don't forget to fix it there later.