### PR TITLE
188414967 cron notification bug

### DIFF
--- a/classes/AllCrons.php
+++ b/classes/AllCrons.php
@@ -75,15 +75,15 @@ class AllCrons
         $messageArray = array();
         $expired_date = date('Y-m-d', strtotime($upload['responsecomplete_ts'] . $extra_days));
         if(strtotime($expired_date) >= strtotime(date('Y-m-d'))) {
-            if(!array_key_exists('emails_sent_y',$upload) || $upload['emails_sent_y___1'] == '0') {
+            if(!array_key_exists('emails_sent_y___1',$upload) || $upload['emails_sent_y___1'] == '0') {
                 if($email) {
                     //Save data on project
                     $Proj = new \Project($pidsArray['DATAUPLOAD']);
                     $event_id = $Proj->firstEventId;
                     $arraySaveDU = array();
-                    $arraySaveDU[$upload['record_id']][$event_id]['emails_sent_y'] = array(1 => "1");//checkbox
+                    $arraySaveDU[$upload['record_id']][$event_id]['emails_sent_y___1'] = array(1 => "1");//checkbox
                     $results = \Records::saveData($pidsArray['DATAUPLOAD'], 'array', $arraySaveDU, 'overwrite', 'YMD', 'flat', '', true, true, true, false, true, array(), true, false);
-                    \Records::addRecordToRecordListCache($pidsArray['DATAUPLOAD'], $upload['emails_sent_y'], 1);
+                    \Records::addRecordToRecordListCache($pidsArray['DATAUPLOAD'], $upload['emails_sent_y___1'], 1);
                 }
 
                 $downloaders_list = "";

--- a/classes/AllCrons.php
+++ b/classes/AllCrons.php
@@ -9,7 +9,7 @@ class AllCrons
         $messageArray = array();
         $expired_date = self::sendEmailToday($upload, $extra_days_delete, $extra_days, $extra_days2);
         if ($expired_date != null) {
-            if ($sop['sop_downloaders'] != "") {
+            if ($sop['sop_downloaders'] !== "") {
                 $downloaders = explode(',', $sop['sop_downloaders']);
                 $number_downloaders = count($downloaders);
                 $messageArray['numDownloaders'] = $number_downloaders;
@@ -188,7 +188,7 @@ class AllCrons
         $message['requests_finalized'] = 0;
         $message['active_data_calls'] = 0;
         foreach ($requests as $req){
-            if((!array_key_exists('finalize_y',$req) || $req['finalize_y'] == "") && $req['due_d'] != "" ){
+            if((!array_key_exists('finalize_y',$req) || $req['finalize_y'] === "") && $req['due_d'] !== "" ){
                 $message['active_requests'] = $message['active_requests'] + 1;
                 $isEmpty = false;
                 $datetime = strtotime($req['due_d']);
@@ -413,7 +413,7 @@ class AllCrons
 				sendEmail($peopleUp['email'], $settings['accesslink_sender_email'], $settings['accesslink_sender_name'], $subject, $message, $upload['data_upload_person'],"Dataset deletion notification", $pidsArray['DATAUPLOAD']);
 
 				#to downloaders
-				if ($sop['sop_downloaders'] != "") {
+				if ($sop['sop_downloaders'] !== "") {
 					$downloaders = explode(',', $sop['sop_downloaders']);
 					$number_downloaders = count($downloaders);
 					$messageArray['numDownloaders'] = $number_downloaders;


### PR DESCRIPTION
So it seems there was a variable being checked wrongly as it is a chekbox.
The emails fired because this test project also has a blank timestamp so both check conditions were met due to the bug and this.
I think this would have happened regardless of the migration as this cron only involves the data side.