### PR TITLE
Issue on concept status

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1218,7 +1218,6 @@ function getDataCallConceptsRow($module, $pidsArray, $sop, $isAdmin, $current_us
             }else{
                 $small_screen_class = 'hidden-sm hidden-xs';
             }
-
             $status = $sop['data_response_status'][$region['record_id']];
             $status_row .= "<td style='text-align: center' class='".$small_screen_class."'>";
             $status_icons = getDataCallStatusIcons($status);

--- a/hub/hub_concept_title.php
+++ b/hub/hub_concept_title.php
@@ -356,21 +356,32 @@ if ((!empty($concept) && $concept['adminupdate_d'] != "" && count($concept['admi
             <table class="table sortable-theme-bootstrap" data-sortable>
             <?php
             $q = $module->query("SELECT record FROM ".getDataTable($pidsArray['HARMONIST'])." WHERE field_name = ? AND value IS NOT NULL AND record = ? AND project_id = ?",['datasop_file',$record,$pidsArray['HARMONIST']]);
-
-            $RecordSetSOP = \REDCap::getData($pidsArray['SOP'], 'array', null,null,null,null,false,false,false,"[sop_active] = 1 and [sop_visibility] = 2 and [sop_concept_id] = ".$record);
+            $RecordSetSOP = \REDCap::getData($pidsArray['SOP'], 'array', null);
             $data_requests = ProjectData::getProjectInfoArrayRepeatingInstruments($RecordSetSOP,$pidsArray['SOP']);
-
             ArrayFunctions::array_sort_by_column($data_requests,'sop_updated_dt',SORT_DESC);
             if(!empty($data_requests) || $q->num_rows > 0) {
                 echo getDataCallConceptsHeader($pidsArray['REGIONS'], $current_user['person_region'],$settings['vote_grid']);
                 foreach ($data_requests as $sop) {
-                        echo getDataCallConceptsRow($module, $pidsArray,$sop,$isAdmin,$current_user,$secret_key,$secret_iv,$settings['vote_grid'],'','');
+                    if ($sop['sop_concept_id'] == $record && $sop['sop_active'] == "1" && $sop['sop_visibility'] == "2") {
+                        echo getDataCallConceptsRow(
+                            $module,
+                            $pidsArray,
+                            $sop,
+                            $isAdmin,
+                            $current_user,
+                            $secret_key,
+                            $secret_iv,
+                            $settings['vote_grid'],
+                            '',
+                            ''
+                        );
+                    }
                 }
-                while ($row = db_fetch_assoc($q)){
-                    $RecordSetSOP = \REDCap::getData($pidsArray['SOP'], 'array', null,null,null,null,false,false,false,"[sop_concept_id] = ".$row['record']);
+                while ($rowConcept = db_fetch_assoc($q)){
+                    $RecordSetSOP = \REDCap::getData($pidsArray['SOP'], 'array', null,null,null,null,false,false,false,"[sop_concept_id] = ".$rowConcept['record']);
                     $data_requests_old = ProjectData::getProjectInfoArrayRepeatingInstruments($RecordSetSOP,$pidsArray['SOP']);
                     if(empty($data_requests_old)){
-                        echo getDataCallConceptsRow($module, $pidsArray,$sop,$isAdmin,$current_user,$secret_key,$secret_iv,$settings['vote_grid'],$row['record'],"1");
+                        echo getDataCallConceptsRow($module, $pidsArray,$sop,$isAdmin,$current_user,$secret_key,$secret_iv,$settings['vote_grid'],$rowConcept['record'],"1");
                     }
                 }
             }else{?>


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
- [x] Have other features this PR touches also been tested?
- [x] Has the code been formatted for consistency and readability?
- [x] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
Bug fix on Single Concept page. The region status on Data Requests was showing blank (grey) on all regions.
The bug was due to REDCap not returning repeating instruments when there's a logic search on getData. Fixed it by getting all data and doing the search later.

# Context
A hub user logs in, goes to Concepts, clicks a single concept and on Data Requests the table displays all region statuses.

# Screenshots
Fixed table displaying icons.
<img width="1304" alt="Screenshot 2025-01-14 at 2 14 10 PM" src="https://github.com/user-attachments/assets/ea2a9e24-006d-4bf5-972f-ca591ca906cf" />
