### PR TITLE
issue on splunk with array being null

### DIFF
--- a/classes/REDCapManagement.php
+++ b/classes/REDCapManagement.php
@@ -79,9 +79,12 @@ class REDCapManagement {
         $projects_array = array_merge(self::getProjectsConstantsArray(),self::getSurveyConstantsArray());
         $pidsArray = array();
         foreach ($projects_array as $constant){
-            $pid = \REDCap::getData($project_id, 'json-array', null,array('project_id'),null,null,false,false,false,"[project_constant]='".$constant."'")[0]['project_id'];
-            if($pid !== ""){
-                $pidsArray[$constant] = $pid;
+            $pid_array = \REDCap::getData($project_id, 'json-array', null,array('project_id'),null,null,false,false,false,"[project_constant]='".$constant."'");
+            if(!empty($pid_array) && is_array($pid_array) && is_array($pid_array[0]) && array_key_exists('project_id', $pid_array[0])){
+                $pid = $pid_array[0]['project_id'];
+                if($pid !== ""){
+                    $pidsArray[$constant] = $pid;
+                }
             }
         }
         $pidsArray['PROJECTS'] = $project_id;


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
- [x] Have other features this PR touches also been tested?
- [x] Has the code been formatted for consistency and readability?
- [x] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
There's an issue when trying to access the pids where the array seems to be blank.

# Context
Splunk message:

2/5/258:27:32.000 AM | Error message: Warning - Trying to access array offset on value of type null, File: /app001/www/redcap/modules/harmonist-hub_v1.0/classes/REDCapManagement.php, Line: 82host = ori1123lpsource = /app001/www-logs/redcap_cron_logsourcetype = victr_cron_log
-- | --
