### PR TITLE
Error on new installation

### DIFF
--- a/classes/SecurityHandler.php
+++ b/classes/SecurityHandler.php
@@ -106,6 +106,9 @@ class SecurityHandler
             if ($projectId == null) {
                 $projectId = $this->pidsArray['SETTINGS'];
             }
+            if($projectId == null){
+                return [];
+            }
             $settings = REDCap::getData($projectId, 'json-array', null)[0];
 
             if (!empty($settings)) {

--- a/classes/SecurityHandler.php
+++ b/classes/SecurityHandler.php
@@ -105,9 +105,9 @@ class SecurityHandler
         if (empty($this->settings)) {
             if ($projectId == null) {
                 $projectId = $this->pidsArray['SETTINGS'];
-            }
-            if($projectId == null){
-                return [];
+                if($projectId == null){
+                    return [];
+                }
             }
             $settings = REDCap::getData($projectId, 'json-array', null)[0];
 


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Are all the features in this PR tested? 
- [x] Have other features this PR touches also been tested?
- [x] Has the code been formatted for consistency and readability?
- [x] Did you also update related documentation and tooling, such as .readme or tests?

# Overview
Encountered an error locally when installing a new Hub instance on a project that has data but does not follow the data dictionary recommendations.

# Context
Error message: Uncaught TypeError: Cannot access offset of type string on string in modules/harmonist-hub_v1.0.0/classes/SecurityHandler.php:130 Stack trace: #0 modules/harmonist-hub_v1.0.0/classes/SecurityHandler.php(33): Vanderbilt\HarmonistHubExternalModule\SecurityHandler->getSettingsData() #1 modules/harmonist-hub_v1.0.0/HarmonistHubExternalModule.php(503): Vanderbilt\HarmonistHubExternalModule\SecurityHandler->__construct(Object(Vanderbilt\HarmonistHubExternalModule\HarmonistHubExternalModule), 221) #2 modules/harmonist-hub_v1.0.0/index.php(16): Vanderbilt\HarmonistHubExternalModule\HarmonistHubExternalModule->getSecurityHandler() #3 redcap_v14.8.2/ExternalModules/index.php(151): require('/Applications/X...') #4 {main} thrown

